### PR TITLE
Fix cloudfront invalidation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,11 +6,7 @@ on:
       - master
 
 env:
-  AWS_S3_BUCKET_TEST: ${{ secrets.AWS_S3_BUCKET_TEST }}
-  AWS_S3_BUCKET_PROD: ${{ secrets.AWS_S3_BUCKET_PROD }}
-  DISTRIBUTION_ID_TEST: ${{ secrets.DISTRIBUTION_ID_TEST }}
-  DISTRIBUTION_ID_PROD: ${{ secrets.DISTRIBUTION_ID_PROD }}
-  PATHS: '/*'
+  PATHS: "/*"
   SOURCE_DIR: "./frontend/build"
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -47,13 +43,13 @@ jobs:
         with:
           args: --acl public-read --delete
         env:
-          AWS_S3_BUCKET: $AWS_S3_BUCKET_TEST
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET_TEST }}
 
       - name: Invalidate Cloudfront Staging
         if: github.ref == 'refs/heads/develop'
         uses: muratiger/invalidate-cloudfront-and-wait-for-completion-action@master
         env:
-          DISTRIBUTION_ID: $DISTRIBUTION_ID_TEST
+          DISTRIBUTION_ID: ${{ secrets.DISTRIBUTION_ID_TEST }}
 
       - name: Deploy to S3 Production
         if: github.ref == 'refs/heads/master'
@@ -61,10 +57,10 @@ jobs:
         with:
           args: --acl public-read --delete
         env:
-          AWS_S3_BUCKET: $AWS_S3_BUCKET_PROD
+          AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET_PROD }}
 
       - name: Invalidate Cloudfront Production
         if: github.ref == 'refs/heads/master'
         uses: muratiger/invalidate-cloudfront-and-wait-for-completion-action@master
         env:
-          DISTRIBUTION_ID: $DISTRIBUTION_ID_PROD
+          DISTRIBUTION_ID: ${{ secrets.DISTRIBUTION_ID_PROD }}


### PR DESCRIPTION
This PR fixes the way we're using secrets in the deployment workflow, allowing for automatic object invalidation. 

While the `AWS_S3_BUCKET_*` secrets were picked up by their respective actions, the `$DISTRIBUTION_ID_*` ones were not, as we can see from the error message:

> An error occurred (AccessDenied) when calling the CreateInvalidation operation: User: arn:aws:iam::421329321045:user/s3-deployment-ce-ma-fac is not authorized to perform: cloudfront:CreateInvalidation on resource: arn:aws:cloudfront::421329321045:distribution/$DISTRIBUTION_ID_PROD

This change has already been tested and implemented in code4romania/diaspora-hub#54

This also comes with a IAM policy change, since `cloudfront:CreateInvalidation` [doesn't support resource-level permissions](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cf-api-permissions-ref.html#required-permissions-invalidations).